### PR TITLE
Fix: Include skills in setup and remove outdated tags

### DIFF
--- a/.github/prompts/terraform-context.prompt.md
+++ b/.github/prompts/terraform-context.prompt.md
@@ -31,7 +31,7 @@ The output follows the [AGENTS.md](https://agents.md/) format - a simple, open f
 5.  **Documentation Generation**: Generate initial docs in `docs/` in the **Target Language**.
 6.  **Knowledge Base Translation**: Translate `knowledge/` files if the Target Language is not English.
 7.  **AGENTS.md Generation**: Generate the `AGENTS.md` file following the format in the **Target Language**.
-8.  **Agent, Command & Skill Translation**: Translate agents, commands, and skills (if Target Language is not English).
+8.  **Agent, Command, and Skill Translation**: Translate agents, commands, and skills (if Target Language is not English).
 9.  **Final Check**: Review the "Final Check" section.
 
 ## 🛠️ Generation Logic

--- a/.github/prompts/terraform-context.prompt.md
+++ b/.github/prompts/terraform-context.prompt.md
@@ -111,7 +111,7 @@ If the **Target Language** is NOT English:
 
 _Note: Create these files with initial content based on your analysis. They will be refined by the @Librarian later._
 
-### Step 6: Agent, Command & Skill Translation
+### Step 6: Agent, Command, and Skill Translation
 
 If the **Target Language** is NOT English:
 

--- a/.github/prompts/terraform-context.prompt.md
+++ b/.github/prompts/terraform-context.prompt.md
@@ -31,7 +31,7 @@ The output follows the [AGENTS.md](https://agents.md/) format - a simple, open f
 5.  **Documentation Generation**: Generate initial docs in `docs/` in the **Target Language**.
 6.  **Knowledge Base Translation**: Translate `knowledge/` files if the Target Language is not English.
 7.  **AGENTS.md Generation**: Generate the `AGENTS.md` file following the format in the **Target Language**.
-8.  **Agent & Command Translation**: Translate agents and commands (if Target Language is not English).
+8.  **Agent, Command & Skill Translation**: Translate agents, commands, and skills (if Target Language is not English).
 9.  **Final Check**: Review the "Final Check" section.
 
 ## 🛠️ Generation Logic
@@ -111,7 +111,7 @@ If the **Target Language** is NOT English:
 
 _Note: Create these files with initial content based on your analysis. They will be refined by the @Librarian later._
 
-### Step 6: Agent & Command Translation
+### Step 6: Agent, Command & Skill Translation
 
 If the **Target Language** is NOT English:
 
@@ -125,7 +125,7 @@ If the **Target Language** is NOT English:
 > 2. **PRESERVE STRUCTURE**: Keep all structure, bullet points, and warnings.
 > 3. **MAINTAIN INTENSITY**: Do not soften "MUST" to "should".
 
-1.  **Read** all files in `.github/agents/` and `.github/prompts/`.
+1.  **Read** all files in `.github/agents/`, `.github/prompts/`, and `.github/skills/`.
 2.  **Translate** the content of each file into the **Target Language**.
 3.  **Overwrite** the files in their respective directories.
     - _Note_: Do NOT specify `tools` in the generated agent file. Omitting the `tools` field ensures all available tools are accessible.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ git clone https://github.com/LongbowXXX/terraformer.git
 # Copy the configuration engine to your legacy project
 cp -r terraformer/.github/prompts ./my-legacy-project/.github/
 cp -r terraformer/.github/agents ./my-legacy-project/.github/
+cp -r terraformer/.github/skills ./my-legacy-project/.github/
 cp -r terraformer/knowledge ./my-legacy-project/
 ```
 

--- a/docs/PROJECT_CHARTER.md
+++ b/docs/PROJECT_CHARTER.md
@@ -48,7 +48,7 @@ As Generative AI becomes integral to development, simply assigning a persona (e.
 
 ### Solved & Remaining Challenges (v1.4 Focus)
 
-1.  **Procedural Drift (New):** Agents may understand _what_ to do but often forget _how_ to do it correctly (e.g., skipping step-by-step reasoning or ignoring output formats).
+1.  **Procedural Drift:** Agents may understand _what_ to do but often forget _how_ to do it correctly (e.g., skipping step-by-step reasoning or ignoring output formats).
 2.  **Role-Capability Mismatch:** A "Senior Engineer" agent without access to specific testing or refactoring methodologies is prone to hallucination or low-quality output.
 3.  **Context Debt:** The persistent issue of implicit knowledge hindering AI understanding.
 
@@ -65,12 +65,12 @@ By analyzing a target project, Terraformer provides a complete package:
 
 The protocol establishes four integrated layers within a project:
 
-| Layer  | Name             | Role                                                                             | Implementation                |
-| :----- | :--------------- | :------------------------------------------------------------------------------- | :---------------------------- |
-| **L1** | **Constitution** | Project Rules & Laws                                                             | `AGENTS.md`                   |
-| **L2** | **Commands**     | **(New)** Standardized Task Procedures<br>(e.g., Planning, Testing, Refactoring) | `.github/prompts/*.prompt.md` |
-| **L3** | **Knowledge**    | Explicit Context Map                                                             | `docs/*`                      |
-| **L4** | **Agents**       | Specialized Roles with Authority                                                 | `.github/agents/*.agent.md`   |
+| Layer  | Name             | Role                                                                   | Implementation                |
+| :----- | :--------------- | :--------------------------------------------------------------------- | :---------------------------- |
+| **L1** | **Constitution** | Project Rules & Laws                                                   | `AGENTS.md`                   |
+| **L2** | **Commands**     | Standardized Task Procedures<br>(e.g., Planning, Testing, Refactoring) | `.github/prompts/*.prompt.md` |
+| **L3** | **Knowledge**    | Explicit Context Map                                                   | `docs/*`                      |
+| **L4** | **Agents**       | Specialized Roles with Authority                                       | `.github/agents/*.agent.md`   |
 
 ## 6. Architecture: Roles & Commands Matrix
 


### PR DESCRIPTION
## 1. Context (The "Why")

- **Motivation/Background:**
  - The `skills` directory was recently introduced but was missing from the `terraform-context` prompt's translation logic and the `README`'s installation commands. This ensures proper setup and translation for non-English targets.
  - The `PROJECT_CHARTER.md` contained outdated "(New)" tags that are no longer accurate.

## 2. Changes (The "What")

- **Summary:**
  - Updated **`terraform-context.prompt.md`** to include `skills` in the translation/copy process.
  - Updated **`README.md`** installation instructions to copy `.github/skills`.
  - Removed outdated "(New)" tags from **`PROJECT_CHARTER.md`**.

- **Impact Scope:**
  - Documentation and Prompt Logic.

- **Technical Decisions:**
  - N/A

- **Migration/Breaking Changes:**
  - None

## 3. Verification (The "Proof")

- **Coverage:** Verified that the instructions now explicitly include the missing `skills` directory and that the text in the charter is cleaner.

### Manual Tests
- [x] Verified `README.md` contains the `cp` command for skills.
- [x] Verified `terraform-context.prompt.md` includes `.github/skills/` in the read list.

## 4. Risks

- None.

## 5. Self-Check

- [x] Title is clear and concise.
- [x] Description is complete and follows the structure above.
- [x] Code has been linted and formatted.
- [x] Tests pass locally.
- [x] No extraneous files (debug logs, temp files) are included.